### PR TITLE
Clarify error support description in multinomial_choice1

### DIFF
--- a/Week 3- Statistical Demand Models/multinomial_choice1.tex
+++ b/Week 3- Statistical Demand Models/multinomial_choice1.tex
@@ -69,7 +69,7 @@ There are some choices that make our life easier
 
 \begin{frame}
 \frametitle{Errors}
-Allowing for full support $(-\infty, \infty)$ errors provide two key features:
+Allowing for a continuous density with full support $(-\infty, \infty)$ errors provide two key features:
 \begin{itemize}
 \item Smoothness: $s_{ij}$ is everywhere continuously differentiable in $V_{ij}$.
 \item Bound $s_{ij} \in (0,1)$ so that we can rationalize any observed pattern in the data.


### PR DESCRIPTION
I believe that soley assuming full support does not allow you to conclude that $s_{ij}$ is everywhere continuously differentiable with respect to $V_{ij}$. I believe it's the _continuity_ of the density that would give you differentiability-- there are no mass points in the density that would allow for a positive probability of a tie for two alternatives